### PR TITLE
Update Condition.tsx

### DIFF
--- a/packages/easy-email-extensions/src/AttributePanel/components/attributes/Condition.tsx
+++ b/packages/easy-email-extensions/src/AttributePanel/components/attributes/Condition.tsx
@@ -93,13 +93,6 @@ export function Condition() {
 
   }, [change, condition, values]);
 
-  if (
-    !focusBlock?.type ||
-    !Object.values(AdvancedType).includes(focusBlock?.type as any)
-  ) {
-    return null;
-  }
-
   const isEmpty = !condition?.groups.length;
 
   return (


### PR DESCRIPTION
We can't use `Condition` in custom blocks.
Not sure why these lines are here, but I suspect they don't need to be here.