### PR TITLE
chore: moving dependencies to dev dependencies

### DIFF
--- a/packages/easy-email-core/package.json
+++ b/packages/easy-email-core/package.json
@@ -66,15 +66,15 @@
     "ts-node": "^10.4.0",
     "tsc-alias": "^1.4.1",
     "tsconfig-paths": "^3.11.0",
-    "vite": "^2.5.6"
-  },
-  "dependencies": {
+    "vite": "^2.5.6",
     "@types/js-beautify": "^1.13.3",
     "@types/uuid": "^8.3.4",
+    "typescript": "^4.4.4"
+  },
+  "dependencies": {
     "js-beautify": "^1.14.4",
     "lodash": "^4.17.21",
     "nanoid": "^3.3.1",
-    "typescript": "^4.4.4",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {

--- a/packages/easy-email-core/yarn.lock
+++ b/packages/easy-email-core/yarn.lock
@@ -2910,6 +2910,8 @@ globals@^13.6.0, globals@^13.9.0:
   version "13.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.12.0.tgz#4d733760304230a0082ed96e21e5c565f898089e"
   integrity sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==
+  dependencies:
+    type-fest "^0.20.2"
 
 globby@^11.0.3, globby@^11.0.4:
   version "11.0.4"
@@ -4985,11 +4987,6 @@ type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.21.3:
   version "0.21.3"

--- a/packages/easy-email-editor/package.json
+++ b/packages/easy-email-editor/package.json
@@ -33,8 +33,6 @@
     ]
   },
   "dependencies": {
-    "@types/final-form-set-field-touched": "^1.0.0",
-    "@types/is-hotkey": "^0.1.7",
     "final-form": "^4.20.4",
     "final-form-arrays": "^3.0.2",
     "final-form-set-field-touched": "^1.0.1",
@@ -44,6 +42,8 @@
     "react-use": "^17.3.1"
   },
   "devDependencies": {
+    "@types/final-form-set-field-touched": "^1.0.0",
+    "@types/is-hotkey": "^0.1.7",
     "@types/lodash": "^4.14.178",
     "@types/node": "^16.11.7",
     "@types/react": "17.0.2",

--- a/packages/easy-email-editor/yarn.lock
+++ b/packages/easy-email-editor/yarn.lock
@@ -1229,6 +1229,8 @@ globals@^13.6.0, globals@^13.9.0:
   version "13.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.12.0.tgz#4d733760304230a0082ed96e21e5c565f898089e"
   integrity sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==
+  dependencies:
+    type-fest "^0.20.2"
 
 globby@^11.0.3, globby@^11.0.4:
   version "11.0.4"
@@ -2382,11 +2384,6 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
-
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 typescript@^4.6.3:
   version "4.6.3"

--- a/packages/easy-email-extensions/package.json
+++ b/packages/easy-email-extensions/package.json
@@ -59,13 +59,13 @@
     "typescript": "^4.4.4",
     "vite": "^2.6.14",
     "vite-plugin-html": "^2.1.1",
-    "vite-plugin-style-import": "^1.3.0"
+    "vite-plugin-style-import": "^1.3.0",
+    "@types/color": "^3.0.3",
+    "@types/react-color": "^3.0.6",
+    "@types/uuid": "^8.3.4"
   },
   "dependencies": {
     "@arco-design/web-react": "^2.36.1",
-    "@types/color": "^3.0.3",
-    "@types/react-color": "^3.0.6",
-    "@types/uuid": "^8.3.4",
     "codemirror": "^5.63.3",
     "color": "^4.2.3",
     "final-form": "^4.20.4",

--- a/packages/easy-email-extensions/yarn.lock
+++ b/packages/easy-email-extensions/yarn.lock
@@ -3349,6 +3349,8 @@ globals@^13.6.0, globals@^13.9.0:
   version "13.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.12.0.tgz#4d733760304230a0082ed96e21e5c565f898089e"
   integrity sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==
+  dependencies:
+    type-fest "^0.20.2"
 
 globby@^11.0.2, globby@^11.0.3, globby@^11.0.4:
   version "11.0.4"
@@ -6475,11 +6477,6 @@ type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
   integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
-
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.21.3:
   version "0.21.3"


### PR DESCRIPTION
All types, and especially `typescript`, should be in `devDependencies`. 

It will prevent package bundlers like `aws serverless` to pick up a 64MB typescript package into the bundle.
When you think of using this library in node aws lambda for example, which has a 50MB (zipped) and (250MB unzipped) limit to upload package, this makes a big difference :) 


<img width="505" alt="image" src="https://user-images.githubusercontent.com/6645382/223593148-22dbe533-de9e-47ba-92e1-c0d9f259f02c.png">
