### PR TITLE
fix: using uuid dependency only + fixed crypto issue for library build

### DIFF
--- a/packages/easy-email-core/package.json
+++ b/packages/easy-email-core/package.json
@@ -73,7 +73,6 @@
   "dependencies": {
     "js-beautify": "^1.14.4",
     "lodash": "^4.17.21",
-    "nanoid": "^3.3.1",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {

--- a/packages/easy-email-core/src/utils/TemplateEngineManager.tsx
+++ b/packages/easy-email-core/src/utils/TemplateEngineManager.tsx
@@ -2,7 +2,7 @@ import { AdvancedBlock, Operator } from '@core/blocks/advanced/generateAdvancedB
 import { Raw } from '@core/components';
 import { isNumber } from 'lodash';
 import React from 'react';
-import { nanoid } from 'nanoid';
+import { v4 as uuidv4 } from 'uuid';
 
 function generateIterationTemplate(
   option: NonNullable<AdvancedBlock['data']['value']['iteration']>,
@@ -51,7 +51,7 @@ function generateConditionTemplate(
       (isNumber(condition.right) ? condition.right : `"${condition.right}"`)
     );
   };
-  const uuid = nanoid(5);
+  const uuid = uuidv4();
   const variables = groups.map((_, index) => `con_${index}_${uuid}`);
 
   const assignExpression = groups

--- a/packages/easy-email-core/vite.config.ts
+++ b/packages/easy-email-core/vite.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
         'react-dom',
         'react-dom/server',
         'lodash',
+        // Let uuid library handle how to use its crypto module depending on the environment
+        // Otherwise, uuid will be bundled into a specific environment (here would it would expect to be in a browser environment)
+        // and any project importing easy-email-core in a node environment would fail with a missing 'crypto' module error
+        'uuid'
       ],
       output: {},
     },

--- a/packages/easy-email-core/vite.config.ts
+++ b/packages/easy-email-core/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         'react-dom/server',
         'lodash',
         // Let uuid library handle how to use its crypto module depending on the environment
-        // Otherwise, uuid will be bundled into a specific environment (here would it would expect to be in a browser environment)
+        // Otherwise, uuid will be bundled into a specific environment (here it would expect to be in a browser environment)
         // and any project importing easy-email-core in a node environment would fail with a missing 'crypto' module error
         'uuid'
       ],

--- a/packages/easy-email-core/yarn.lock
+++ b/packages/easy-email-core/yarn.lock
@@ -4039,11 +4039,6 @@ nanoid@^3.1.30:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
   integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
 
-nanoid@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
-  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"


### PR DESCRIPTION
If we don't exclude `uuid` in vite bundler config, we end up having a wrong uuid version bundled, breaking easy-email-core usage in a nodeJS backend environment.

What this PR does: 
- Removed `nanoid` to use only one library that generates uuid 
- Added `uuid` (and a clear explanation) in the `external` section in vite.config file 

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/6645382/224078891-1968ceac-1212-4835-8349-b0ca3b289437.png">
