### PR TITLE
fix: Falsy value not working with false boolean

### DIFF
--- a/packages/easy-email-core/src/utils/TemplateEngineManager.tsx
+++ b/packages/easy-email-core/src/utils/TemplateEngineManager.tsx
@@ -41,7 +41,7 @@ function generateConditionTemplate(
       return condition.left;
     }
     if (condition.operator === Operator.FALSY) {
-      return condition.left + ' == nil';
+      return `${condition.left} == nil or ${condition.left} == false`;
     }
     return (
       condition.left +

--- a/packages/easy-email-core/src/utils/__tests__/condition.test.tsx
+++ b/packages/easy-email-core/src/utils/__tests__/condition.test.tsx
@@ -3,7 +3,7 @@ import { BlockManager } from './../BlockManager';
 import { JsonToMjml } from '../JsonToMjml';
 import { Liquid } from 'liquidjs';
 import { AdvancedType, BasicType } from '@core/constants';
-import { AdvancedBlock, OperatorSymbol, Operator } from '@core/blocks';
+import { AdvancedBlock, OperatorSymbol, Operator, ICondition } from '@core/blocks';
 
 const Page = BlockManager.getBlockByType(BasicType.PAGE)!;
 const Section = BlockManager.getBlockByType<AdvancedBlock>(
@@ -20,36 +20,17 @@ describe('Test condition.test', () => {
       age: 26,
       job: 'backend',
       email: 'easy-email@gmail.com',
+      fired: false
     },
   };
 
-  it('should be visible when condition is not enabled', () => {
-    const content = Page.create({
+  const createPageWithCondition = (condition: ICondition, content: string) => {
+    return Page.create({
       children: [
         Section.create({
           data: {
             value: {
-              condition: {
-                enabled: false,
-                groups: [
-                  {
-                    groups: [
-                      {
-                        left: 'user.name',
-                        operator: Operator.EQUAL,
-                        right: mergeTags.user.name,
-                      },
-                      {
-                        left: 'user.job',
-                        operator: Operator.EQUAL,
-                        right: 'mergeTags.user.job',
-                      },
-                    ],
-                    symbol: OperatorSymbol.AND,
-                  },
-                ],
-                symbol: OperatorSymbol.AND,
-              },
+              condition
             },
           },
           children: [
@@ -58,7 +39,7 @@ describe('Test condition.test', () => {
                 Text.create({
                   data: {
                     value: {
-                      content: 'this will be visible',
+                      content
                     },
                   },
                 }),
@@ -68,6 +49,31 @@ describe('Test condition.test', () => {
         }),
       ],
     });
+  }
+
+  it('should be visible when condition is not enabled', () => {
+    const expectedContent = 'this will be visible';
+    const content = createPageWithCondition({
+      enabled: false,
+      groups: [
+        {
+          groups: [
+            {
+              left: 'user.name',
+              operator: Operator.EQUAL,
+              right: mergeTags.user.name,
+            },
+            {
+              left: 'user.job',
+              operator: Operator.EQUAL,
+              right: 'mergeTags.user.job',
+            },
+          ],
+          symbol: OperatorSymbol.AND,
+        },
+      ],
+      symbol: OperatorSymbol.AND,
+    }, expectedContent)
 
     const tpl = engine.parse(
       JsonToMjml({
@@ -78,54 +84,32 @@ describe('Test condition.test', () => {
       })
     );
     const html = engine.renderSync(tpl, mergeTags);
-    expect(html).toContain('this will be visible');
+    expect(html).toContain(expectedContent);
   });
 
-  it('should be hide when result is false', () => {
-    const content = Page.create({
-      children: [
-        Section.create({
-          data: {
-            value: {
-              condition: {
-                enabled: true,
-                groups: [
-                  {
-                    groups: [
-                      {
-                        left: 'user.name',
-                        operator: Operator.EQUAL,
-                        right: mergeTags.user.name,
-                      },
-                      {
-                        left: 'user.job',
-                        operator: Operator.EQUAL,
-                        right: 'mergeTags.user.job',
-                      },
-                    ],
-                    symbol: OperatorSymbol.AND,
-                  },
-                ],
-                symbol: OperatorSymbol.AND,
-              },
+  it('should be hidden when result is false', () => {
+    const expectedContent = 'this will be hidden';
+    const content = createPageWithCondition({
+      enabled: true,
+      groups: [
+        {
+          groups: [
+            {
+              left: 'user.name',
+              operator: Operator.EQUAL,
+              right: mergeTags.user.name,
             },
-          },
-          children: [
-            Column.create({
-              children: [
-                Text.create({
-                  data: {
-                    value: {
-                      content: 'this will be hide',
-                    },
-                  },
-                }),
-              ],
-            }),
+            {
+              left: 'user.job',
+              operator: Operator.EQUAL,
+              right: 'mergeTags.user.job',
+            },
           ],
-        }),
+          symbol: OperatorSymbol.AND,
+        },
       ],
-    });
+      symbol: OperatorSymbol.AND,
+    }, expectedContent)
 
     const tpl = engine.parse(
       JsonToMjml({
@@ -136,54 +120,32 @@ describe('Test condition.test', () => {
       })
     );
     const html = engine.renderSync(tpl, mergeTags);
-    expect(html).not.toContain('this will be hide');
+    expect(html).not.toContain(expectedContent);
   });
 
   it('should be visible when result is true', () => {
-    const content = Page.create({
-      children: [
-        Section.create({
-          data: {
-            value: {
-              condition: {
-                enabled: true,
-                groups: [
-                  {
-                    groups: [
-                      {
-                        left: 'user.name',
-                        operator: Operator.EQUAL,
-                        right: mergeTags.user.name,
-                      },
-                      {
-                        left: 'user.job',
-                        operator: Operator.EQUAL,
-                        right: mergeTags.user.job,
-                      },
-                    ],
-                    symbol: OperatorSymbol.AND,
-                  },
-                ],
-                symbol: OperatorSymbol.AND,
-              },
+    const expectedContent = 'this will be visible';
+    const content = createPageWithCondition({
+      enabled: true,
+      groups: [
+        {
+          groups: [
+            {
+              left: 'user.name',
+              operator: Operator.EQUAL,
+              right: mergeTags.user.name,
             },
-          },
-          children: [
-            Column.create({
-              children: [
-                Text.create({
-                  data: {
-                    value: {
-                      content: 'this will be visible',
-                    },
-                  },
-                }),
-              ],
-            }),
+            {
+              left: 'user.job',
+              operator: Operator.EQUAL,
+              right: mergeTags.user.job,
+            },
           ],
-        }),
+          symbol: OperatorSymbol.AND,
+        },
       ],
-    });
+      symbol: OperatorSymbol.AND,
+    }, expectedContent)
 
     const tpl = engine.parse(
       JsonToMjml({
@@ -196,4 +158,68 @@ describe('Test condition.test', () => {
     const html = engine.renderSync(tpl, mergeTags);
     expect(html).toContain('this will be visible');
   });
+
+  describe("with Falsy operator", () => {
+    it('should be visible when result is a false boolean', () => {
+      const expectedContent = 'this will be visible';
+      const content = createPageWithCondition({
+        enabled: true,
+        groups: [
+          {
+            groups: [
+              {
+                left: 'user.fired',
+                operator: Operator.FALSY,
+                right: '',
+              }
+            ],
+            symbol: OperatorSymbol.AND,
+          },
+        ],
+        symbol: OperatorSymbol.AND,
+      }, expectedContent)
+
+      const tpl = engine.parse(
+        JsonToMjml({
+          data: content,
+          mode: 'production',
+          context: content,
+          dataSource: {},
+        })
+      );
+      const html = engine.renderSync(tpl, mergeTags);
+      expect(html).toContain('this will be visible');
+    });
+
+    it('should be visible when result is nil', () => {
+      const expectedContent = 'this will be visible';
+      const content = createPageWithCondition({
+        enabled: true,
+        groups: [
+          {
+            groups: [
+              {
+                left: 'user.nilAttribute',
+                operator: Operator.FALSY,
+                right: '',
+              }
+            ],
+            symbol: OperatorSymbol.AND,
+          },
+        ],
+        symbol: OperatorSymbol.AND,
+      }, expectedContent)
+
+      const tpl = engine.parse(
+        JsonToMjml({
+          data: content,
+          mode: 'production',
+          context: content,
+          dataSource: {},
+        })
+      );
+      const html = engine.renderSync(tpl, mergeTags);
+      expect(html).toContain('this will be visible');
+    })
+  })
 });


### PR DESCRIPTION
According to liquidJS documentation: https://shopify.github.io/liquid/basics/truthy-and-falsy/ 

`false` and `nil` values are considered as `falsy`. The current implementation didn't account for `false` boolean value when selecting `Falsy` in the operator dropdown. This would prevent us from using a `false` boolean in merge tags.


<img width="1251" alt="Screenshot 2023-03-13 at 4 24 41 PM" src="https://user-images.githubusercontent.com/6645382/224827438-242dabdb-34e9-4ea1-a7be-bf9d4045225e.png">
<img width="1228" alt="Screenshot 2023-03-13 at 4 24 50 PM" src="https://user-images.githubusercontent.com/6645382/224827448-4e773b17-71de-41a7-b9e0-504463e63217.png">
<img width="1288" alt="Screenshot 2023-03-13 at 4 24 57 PM" src="https://user-images.githubusercontent.com/6645382/224827449-249a3f26-e967-4029-9ef7-0e3181daf9b8.png">
