### PR TITLE
chore: override console only when email provider is being used

### DIFF
--- a/packages/easy-email-editor/src/components/Provider/EmailEditorProvider/index.tsx
+++ b/packages/easy-email-editor/src/components/Provider/EmailEditorProvider/index.tsx
@@ -12,6 +12,7 @@ import setFieldTouched from 'final-form-set-field-touched';
 import { FocusBlockLayoutProvider } from '../FocusBlockLayoutProvider';
 import { PreviewEmailProvider } from '../PreviewEmailProvider';
 import { LanguageProvider } from '../LanguageProvider';
+import { overrideErrorLog, restoreErrorLog } from '@/utils/logger';
 
 export interface EmailEditorProviderProps<T extends IEmailTemplate = any>
   extends PropsProviderProps {
@@ -36,6 +37,13 @@ export const EmailEditorProvider = <T extends any>(
       content: data.content,
     };
   }, [data]);
+
+  useEffect(() => {
+    overrideErrorLog();
+    return () => {
+      restoreErrorLog();
+    };
+  }, []);
 
   if (!initialValues.content) return null;
 

--- a/packages/easy-email-editor/src/utils/HtmlStringToReactNodes.tsx
+++ b/packages/easy-email-editor/src/utils/HtmlStringToReactNodes.tsx
@@ -11,28 +11,9 @@ import { isNavbarBlock } from './isNavbarBlock';
 
 const domParser = new DOMParser();
 
-const errLog = console.error;
-
 export function getChildSelector(selector: string, index: number) {
   return `${selector}-${index}`;
 }
-
-console.error = (message?: any, ...optionalParams: any[]) => {
-  // ignore validateDOMNesting
-  if (
-    typeof message === 'string' &&
-    [
-      'Unsupported vendor-prefixed style property',
-      'validateDOMNesting',
-      'Invalid DOM',
-      'You provided a `checked` prop to a form field without an `onChange` handler',
-    ].some((item) => message.includes(item))
-  ) {
-    // no console
-  } else {
-    errLog(message, ...optionalParams);
-  }
-};
 
 export interface HtmlStringToReactNodesOptions {
   enabledMergeTagsBadge: boolean;

--- a/packages/easy-email-editor/src/utils/logger.ts
+++ b/packages/easy-email-editor/src/utils/logger.ts
@@ -1,0 +1,24 @@
+const originalErrorLog = console.error;
+
+// ignore expected error logs from easy-email
+export const overrideErrorLog = () => {
+  console.error = (message?: any, ...optionalParams: any[]) => {
+    if (
+      typeof message === 'string' &&
+      [
+        'Unsupported vendor-prefixed style property',
+        'validateDOMNesting',
+        'Invalid DOM',
+        'You provided a `checked` prop to a form field without an `onChange` handler',
+      ].some((item) => message.includes(item))
+    ) {
+      // no console
+    } else {
+      originalErrorLog(message, ...optionalParams);
+    }
+  };
+}
+
+export const restoreErrorLog = () => {
+  console.error = originalErrorLog;
+}


### PR DESCRIPTION
Easy-email currently overrides `console.error` completely for the entire project using it. 

It can hide real errors coming from the project using easy-email, which is undesirable. I'm suggesting here to override the `console.error` only when the email provider is being used. We restore the logger as soon as we're done with it.