### PR TITLE
fix: remove escaped char in generated MJML

### DIFF
--- a/packages/easy-email-core/package.json
+++ b/packages/easy-email-core/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
+    "@types/he": "^1.2.0",
     "@types/jest": "^26.0.24",
     "@types/jsdom": "^16.2.13",
     "@types/lodash": "^4.14.178",
@@ -71,6 +72,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
+    "he": "^1.2.0",
     "js-beautify": "^1.14.4",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2"

--- a/packages/easy-email-core/src/utils/JsonToMjml.tsx
+++ b/packages/easy-email-core/src/utils/JsonToMjml.tsx
@@ -1,10 +1,10 @@
 import { html } from 'js-beautify';
-import { unescape } from 'lodash';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { BlockManager } from '@core/utils';
 import { JsonToMjmlOption } from './isProductionMode';
 import React, { useContext } from 'react';
 import { IBlockData } from '@core/typings';
+import { unescape } from 'he'
 
 type EmailRenderProps = {
   mode: 'production' | 'testing';

--- a/packages/easy-email-core/src/utils/__tests__/JsonToMjml.test.ts
+++ b/packages/easy-email-core/src/utils/__tests__/JsonToMjml.test.ts
@@ -31,7 +31,7 @@ describe('Test JsonToMjml when responsive is "false"', () => {
     context: content,
   });
 
-  it('should contains the mark of "<meta name="viewport" />"', () => {
+  it('should contain the mark of "<meta name="viewport" />"', () => {
     expect(parseHtml).toContain('<meta name="viewport" />');
   });
 });
@@ -123,3 +123,30 @@ describe('Test JsonToMjml when mode is "production"', () => {
     expect(parseHtml).toMatchSnapshot();
   });
 });
+
+describe('json with manual variables added to content', () => {
+  const content = Page.create({
+    children: [
+      Section.create({
+        children: [
+          Column.create({
+            children: [Text.create({data:{value:{content: `<div>{% assign iteration_example = "First,Second,Third,Fourth,Fifth" | split: ',' %}</div>`
+            }}})],
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const parseHtml = JsonToMjml({
+    data: content,
+    mode: 'testing',
+    context: content,
+    idx: 'content',
+  });
+
+  it('should render without any escaped HTML characters', () => {
+    console.log('parseHtml', parseHtml);
+    expect(parseHtml).toMatchSnapshot();
+  });
+})

--- a/packages/easy-email-core/src/utils/__tests__/__snapshots__/JsonToMjml.test.ts.snap
+++ b/packages/easy-email-core/src/utils/__tests__/__snapshots__/JsonToMjml.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Test JsonToMjml when mode is "production" should render as expected 1`]
               
     <mj-html-attributes>
       <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"text-color\\" text-color=\\"#000000\\"></mj-html-attribute>
-<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-family\\" font-family=\\"-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;,&#x27;Helvetica Neue&#x27;, sans-serif\\"></mj-html-attribute>
+<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-family\\" font-family=\\"-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans','Helvetica Neue', sans-serif\\"></mj-html-attribute>
 <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-size\\" font-size=\\"14px\\"></mj-html-attribute>
 <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"line-height\\" line-height=\\"1.7\\"></mj-html-attribute>
 <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-weight\\" font-weight=\\"400\\"></mj-html-attribute>
@@ -23,7 +23,7 @@ exports[`Test JsonToMjml when mode is "production" should render as expected 1`]
               
             <mj-attributes>
               
-              <mj-all font-family=\\"-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;,&#x27;Helvetica Neue&#x27;, sans-serif\\" />
+              <mj-all font-family=\\"-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans','Helvetica Neue', sans-serif\\" />
               <mj-text font-size=\\"14px\\" />
               <mj-text color=\\"#000000\\" />
         <mj-text line-height=\\"1.7\\" />
@@ -42,7 +42,7 @@ exports[`Test JsonToMjml when mode is "testing" should render as expected 1`] = 
               
     <mj-html-attributes>
       <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"text-color\\" text-color=\\"#000000\\"></mj-html-attribute>
-<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-family\\" font-family=\\"-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;,&#x27;Helvetica Neue&#x27;, sans-serif\\"></mj-html-attribute>
+<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-family\\" font-family=\\"-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans','Helvetica Neue', sans-serif\\"></mj-html-attribute>
 <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-size\\" font-size=\\"14px\\"></mj-html-attribute>
 <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"line-height\\" line-height=\\"1.7\\"></mj-html-attribute>
 <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-weight\\" font-weight=\\"400\\"></mj-html-attribute>
@@ -58,7 +58,7 @@ exports[`Test JsonToMjml when mode is "testing" should render as expected 1`] = 
               
             <mj-attributes>
               
-              <mj-all font-family=\\"-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;,&#x27;Helvetica Neue&#x27;, sans-serif\\" />
+              <mj-all font-family=\\"-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans','Helvetica Neue', sans-serif\\" />
               <mj-text font-size=\\"14px\\" />
               <mj-text color=\\"#000000\\" />
         <mj-text line-height=\\"1.7\\" />
@@ -68,4 +68,39 @@ exports[`Test JsonToMjml when mode is "testing" should render as expected 1`] = 
             </mj-attributes>
           </mj-head>
           <mj-body background-color=\\"#efeeea\\" width=\\"600px\\" css-class=\\"email-block node-idx-content node-type-page\\" ><mj-section padding=\\"20px 0px 20px 0px\\" border=\\"none\\" direction=\\"ltr\\" text-align=\\"center\\" background-repeat=\\"repeat\\" background-size=\\"auto\\" background-position=\\"top center\\" css-class=\\"email-block node-idx-content.children.[0] node-type-section\\" ><mj-column padding=\\"0px 0px 0px 0px\\" border=\\"none\\" vertical-align=\\"top\\" css-class=\\"email-block node-idx-content.children.[0].children.[0] node-type-column\\" ><mj-text padding=\\"10px 25px 10px 25px\\" align=\\"left\\" css-class=\\"email-block node-idx-content.children.[0].children.[0].children.[0] node-type-text\\" >Make it easy for everyone to compose emails!</mj-text></mj-column></mj-section></mj-body></mjml > "
+`;
+
+exports[`json with manual variables added to content should render without any escaped HTML characters 1`] = `
+"
+          <mjml>
+          <mj-head>
+              
+    <mj-html-attributes>
+      <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"text-color\\" text-color=\\"#000000\\"></mj-html-attribute>
+<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-family\\" font-family=\\"-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans','Helvetica Neue', sans-serif\\"></mj-html-attribute>
+<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-size\\" font-size=\\"14px\\"></mj-html-attribute>
+<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"line-height\\" line-height=\\"1.7\\"></mj-html-attribute>
+<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-weight\\" font-weight=\\"400\\"></mj-html-attribute>
+<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"responsive\\" responsive=\\"true\\"></mj-html-attribute>
+
+    </mj-html-attributes>
+  
+              
+              
+              
+              <mj-breakpoint width=\\"480px\\" />
+              
+              
+            <mj-attributes>
+              
+              <mj-all font-family=\\"-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans','Helvetica Neue', sans-serif\\" />
+              <mj-text font-size=\\"14px\\" />
+              <mj-text color=\\"#000000\\" />
+        <mj-text line-height=\\"1.7\\" />
+        <mj-text font-weight=\\"400\\" />
+              
+
+            </mj-attributes>
+          </mj-head>
+          <mj-body background-color=\\"#efeeea\\" width=\\"600px\\" css-class=\\"email-block node-idx-content node-type-page\\" ><mj-section padding=\\"20px 0px 20px 0px\\" border=\\"none\\" direction=\\"ltr\\" text-align=\\"center\\" background-repeat=\\"repeat\\" background-size=\\"auto\\" background-position=\\"top center\\" css-class=\\"email-block node-idx-content.children.[0] node-type-section\\" ><mj-column padding=\\"0px 0px 0px 0px\\" border=\\"none\\" vertical-align=\\"top\\" css-class=\\"email-block node-idx-content.children.[0].children.[0] node-type-column\\" ><mj-text padding=\\"10px 25px 10px 25px\\" align=\\"left\\" css-class=\\"email-block node-idx-content.children.[0].children.[0].children.[0] node-type-text\\" ><div>{% assign iteration_example = \\"First,Second,Third,Fourth,Fifth\\" | split: ',' %}</div></mj-text></mj-column></mj-section></mj-body></mjml > "
 `;

--- a/packages/easy-email-core/src/utils/__tests__/__snapshots__/createCustomBlock.test.tsx.snap
+++ b/packages/easy-email-core/src/utils/__tests__/__snapshots__/createCustomBlock.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Test createCustomBlock should render as expected 1`] = `
               
     <mj-html-attributes>
       <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"text-color\\" text-color=\\"#000000\\"></mj-html-attribute>
-<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-family\\" font-family=\\"-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;,&#x27;Helvetica Neue&#x27;, sans-serif\\"></mj-html-attribute>
+<mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-family\\" font-family=\\"-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans','Helvetica Neue', sans-serif\\"></mj-html-attribute>
 <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-size\\" font-size=\\"14px\\"></mj-html-attribute>
 <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"line-height\\" line-height=\\"1.7\\"></mj-html-attribute>
 <mj-html-attribute class=\\"easy-email\\" multiple-attributes=\\"false\\" attribute-name=\\"font-weight\\" font-weight=\\"400\\"></mj-html-attribute>
@@ -23,7 +23,7 @@ exports[`Test createCustomBlock should render as expected 1`] = `
               
             <mj-attributes>
               
-              <mj-all font-family=\\"-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;,&#x27;Helvetica Neue&#x27;, sans-serif\\" />
+              <mj-all font-family=\\"-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans','Helvetica Neue', sans-serif\\" />
               <mj-text font-size=\\"14px\\" />
               <mj-text color=\\"#000000\\" />
         <mj-text line-height=\\"1.7\\" />

--- a/packages/easy-email-core/yarn.lock
+++ b/packages/easy-email-core/yarn.lock
@@ -1330,6 +1330,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/he@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/he/-/he-1.2.0.tgz#3845193e597d943bab4e61ca5d7f3d8fc3d572a3"
+  integrity sha512-uH2smqTN4uGReAiKedIVzoLUAXIYLBTbSofhx3hbNqj74Ua6KqFsLYszduTrLCMEAEAozF73DbGi/SC1bzQq4g==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -2968,6 +2973,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
This PR attempts to fix this issue mentioned here: https://github.com/zalify/easy-email/issues/276 

By using a more complete solution to unescape HTML char, we get rid of more unescaped char than what lodash does. This allows us to play and add pretty much anything supported by liquidJS like you can see here: 

![Screenshot 2023-03-23 at 1 10 59 PM](https://user-images.githubusercontent.com/6645382/227296255-aefc9a8b-2699-48e1-90ec-8743e6995e62.png)
![Screenshot 2023-03-23 at 1 11 12 PM](https://user-images.githubusercontent.com/6645382/227296263-86ba9f1c-7543-4601-9678-bcb4f9d6b3b6.png)
