### PR TITLE
Change default locale to en in demo

### DIFF
--- a/demo/src/pages/Editor/index.tsx
+++ b/demo/src/pages/Editor/index.tsx
@@ -198,7 +198,7 @@ export default function Editor() {
   const dispatch = useDispatch();
   const history = useHistory();
   const templateData = useAppSelector('template');
-  const [locale, setLocale] = useState('zh-Hans');
+  const [locale, setLocale] = useState('en');
   const { addCollection, removeCollection, collectionCategory } = useCollection();
   const [visible, setVisible] = useState(false);
   const [text, setText] = useState('');


### PR DESCRIPTION
Default language for demo page is in english but the editor loading in `zh-Hans`